### PR TITLE
Mark nightly builds as beta

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -85,6 +85,7 @@ if [ "$RELEASE" == "true" ]; then
   description="Official Release of $TAG"
   RELEASE_OPTION="--release"
 else
+  TAG="${TAG}-beta"
   description="Nightly Build of $TAG"
 fi
 


### PR DESCRIPTION
Should generate a GitHub release that looks like this:

![Screenshot 2021-06-09 at 15 37 45](https://user-images.githubusercontent.com/20224954/121375454-a9db3880-c938-11eb-8f74-90e189ba1072.png)
