### PR TITLE
Ensure release publish script consistently changes all the timestamps

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -79,7 +79,7 @@ do
     newName=$(echo "${file}" | sed -r "s/${timestampRegex}/$TIMESTAMP/")
 
     if [ "${file}" != "${newName}" ]; then
-      # Rename archive and checksum file with new timestamp
+      # Rename archive and its associated files with new timestamp
       echo "Renaming ${file} to ${newName}"
       mv "${file}" "${newName}"
       mv "${file}.sha256.txt" "${newName}.sha256.txt"
@@ -120,7 +120,7 @@ do
       newName=$(echo "${file}" | sed -r "s/${timestampRegex}/$TIMESTAMP/")
 
       if [ "${file}" != "${newName}" ]; then
-        # Rename archive and checksum file with new timestamp
+        # Rename non-archive file with new timestamp
         echo "Renaming ${file} to ${newName}"
         mv "${file}" "${newName}"
       fi

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -68,7 +68,7 @@ else
    org="--org \"${GITHUB_ORG}\""
 fi
 
-# Rename archive files to ensure a consistent timestamp across release
+# Rename archive files (and their associated files: checksum, metadata, sig) to ensure a consistent timestamp across release
 for file in OpenJDK*
 do
   # If file name is an archive rename timestamp along with it's associated files 

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -33,7 +33,12 @@ timestampRegex="[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]{2}-[[:d
 # IF YOU ARE MODIFYING THIS THEN THE FILE MATCHING IS PROBABLY WRONG, MAKE SURE adoptium/api.adoptium.net and adoptopenjdk/openjdk-api, ARE UPDATED TOO
 #      OpenJDK 8U_             -jdk        x64_           Linux_         hotspot_         2018-06-15-10-10                .tar.gz
 #      OpenJDK 11_             -jdk        x64_           Linux_         hotspot_         11_28                           .tar.gz
-regex="OpenJDK([[:digit:]]+)U?(-jre|-jdk)_([[:alnum:]\-]+)_([[:alnum:]]+)_([[:alnum:]]+).*\.(tar\.gz|zip|pkg|msi)";
+#      OpenJDK 18_             -testimage  x64_           Linux_         hotspot_         18.0.1_10                       .tar.gz
+#      OpenJDK 8U_             -testimage  x64_           Linux_         hotspot_         8u332b09                        .tar.gz
+#      OpenJDK 18U             -jdk-sources                                               2020-06-06-16-36                .tar.gz
+#
+#             (version     )  (type                                                                                           ) (arch           ) (os             ) (variant        ) (timestamp     or version      )  (extension          )
+regex="OpenJDK([[:digit:]]+)U?(-jre|-jdk|-debugimage|-static-libs-glibc|-static-libs|-static-libs-musl|-testimage|-jdk-sources)_([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:digit:]\-]+|[[:alnum:]\._]+)\.(tar\.gz|zip|pkg|msi)";
 regexArchivesOnly="${regex}$";
 
 # Check that a TAG, e.g. jdk11.0.12+7, has been passed in.
@@ -63,13 +68,14 @@ else
    org="--org \"${GITHUB_ORG}\""
 fi
 
-# Rename to ensure a consistent timestamp across release
+# Rename archive files to ensure a consistent timestamp across release
 for file in OpenJDK*
 do
-  echo "Processing $file";
-
+  # If file name is an archive rename timestamp along with it's associated files 
   if [[ $file =~ $regexArchivesOnly ]];
   then
+    echo "Processing archive file: $file";
+
     newName=$(echo "${file}" | sed -r "s/${timestampRegex}/$TIMESTAMP/")
 
     if [ "${file}" != "${newName}" ]; then
@@ -91,9 +97,34 @@ do
     FILE_OS=${BASH_REMATCH[4]};
     FILE_VARIANT=${BASH_REMATCH[5]};
     FILE_TS_OR_VERSION=${BASH_REMATCH[6]};
-    FILE_EXTENSION=${BASH_REMATCH[8]};
+    FILE_EXTENSION=${BASH_REMATCH[7]};
 
     echo "version:${FILE_VERSION} type: ${FILE_TYPE} arch:${FILE_ARCH} os:${FILE_OS} variant:${FILE_VARIANT} timestamp or version:${FILE_TS_OR_VERSION} timestamp:${TIMESTAMP} extension:${FILE_EXTENSION}";
+  fi
+done
+
+# Rename any remaining non-archive file timestamps that have not already been renamed
+for file in OpenJDK*
+do
+  if [[ ! $file =~ $regexArchivesOnly ]];
+  then
+    echo "Processing non-archive file: $file";
+
+    # Check no new file type archive has been added without updating regexArchivesOnly
+    if [[ $file == *.tar.gz ]] || [[ $file == *.zip ]] || [[ $file == *.pkg ]] || [[ $file == *.msi ]]; then
+      "ERROR: ${file} is an archive but does not match regex ${regexArchivesOnly}, please update sbin/Release.sh"
+      exit 1
+    fi
+
+    if [[ $file =~ $timestampRegex ]]; then
+      newName=$(echo "${file}" | sed -r "s/${timestampRegex}/$TIMESTAMP/")
+
+      if [ "${file}" != "${newName}" ]; then
+        # Rename archive and checksum file with new timestamp
+        echo "Renaming ${file} to ${newName}"
+        mv "${file}" "${newName}"
+      fi
+    fi
   fi
 done
 


### PR DESCRIPTION
The current logic in sbin/Release.sh only updates the file name timestamps for jdk|jre archives, and also does not include alpine archives.
This PR ensure any file to publish that contains a timestamp get renamed to the required publish timestamp.
It also corrects the print of the archive type and extends the regex to include all the file types.

eg. Mixture of many different timestamps.. : https://github.com/adoptium/temurin17-binaries/releases/tag/jdk17u-2022-08-12-08-22-beta

Fixes: https://github.com/adoptium/temurin-build/issues/3014

Signed-off-by: Andrew Leonard <anleonar@redhat.com>