### PR TITLE
update: abort program if strip fullpath in sha256.txt failed

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -83,6 +83,10 @@ do
     # Fix checksum file name
     strippedFileName=$(echo "${newName}" | sed -r "s/.+\\///g")
     sed -i -r "s/^([0-9a-fA-F ]+).*/\1${strippedFileName}/g" "${newName}.sha256.txt"
+    if grep -q 'target' "${newName}.sha256.txt"; then
+        echo "${newName}.sha256.txt still has full path, should be stripped!"
+        exit 1
+    fi
 
     FILE_VERSION=${BASH_REMATCH[1]};
     FILE_TYPE=${BASH_REMATCH[2]};


### PR DESCRIPTION
Since we do not know how often this really happens, because it is only the installer job for release encounter such issue.
For the temp. workaround is to make the release job failed so we can see what exactly cause this if the expression is wrong or we get extra char in the file not matching it. then we can modify the script to have less failure.

Ref: https://github.com/adoptium/temurin-build/issues/2865
