### PR TITLE
Update GitHub action dependencies and pin to hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,22 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test_groovy:
     name: Groovy
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
       with:
-        java-version: '11'
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'gradle'
 
     - name: Run Groovy Tests
       run: |


### PR DESCRIPTION
Update the version of GitHub actions used, pin them to hashes, and restrict their permissions.
Part of https://github.com/adoptium/adoptium/issues/187