### PR TITLE
Update publish variant regex to allow underscore for fast_startup artifacts

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -36,9 +36,11 @@ timestampRegex="[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]{2}-[[:d
 #      OpenJDK 18_             -testimage  x64_           Linux_         hotspot_         18.0.1_10                       .tar.gz
 #      OpenJDK 8U_             -testimage  x64_           Linux_         hotspot_         8u332b09                        .tar.gz
 #      OpenJDK 18U             -jdk-sources                                               2020-06-06-16-36                .tar.gz
+#      OpenJDK 11_             -jdk        x64_           Linux_         _fast_startup_   11_28                           .tar.gz
 #
-#             (version     )  (type                                                                                           ) (arch           ) (os             ) (variant        ) (timestamp     or version      )  (extension          )
-regex="OpenJDK([[:digit:]]+)U?(-jre|-jdk|-debugimage|-static-libs-glibc|-static-libs|-static-libs-musl|-testimage|-jdk-sources)_([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:digit:]\-]+|[[:alnum:]\._]+)\.(tar\.gz|zip|pkg|msi)";
+#             (version     )  (type                                                                                           ) (arch           ) (os             ) (variant         ) (timestamp     or version      )  (extension          )
+regex="OpenJDK([[:digit:]]+)U?(-jre|-jdk|-debugimage|-static-libs-glibc|-static-libs|-static-libs-musl|-testimage|-jdk-sources)_([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:alnum:]\-_]+_)?([[:digit:]\-]+|[[:alnum:]\._]+)\.(tar\.gz|zip|pkg|msi)";
+
 regexArchivesOnly="${regex}$";
 
 # Check that a TAG, e.g. jdk11.0.12+7, has been passed in.
@@ -112,7 +114,7 @@ do
 
     # Check no new file type archive has been added without updating regexArchivesOnly
     if [[ $file == *.tar.gz ]] || [[ $file == *.zip ]] || [[ $file == *.pkg ]] || [[ $file == *.msi ]]; then
-      "ERROR: ${file} is an archive but does not match regex ${regexArchivesOnly}, please update sbin/Release.sh"
+      echo "ERROR: ${file} is an archive but does not match regex ${regexArchivesOnly}, please update sbin/Release.sh"
       exit 1
     fi
 


### PR DESCRIPTION
The newly updated regex needs to allow _fast_startup_ as a variant. Now allows "_" in variant name.

Also, fixed missing echo in the ERROR msg.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>