### PR TITLE
releaseCheck.sh: use API query and update counts for SBOM .sig file

### DIFF
--- a/sbin/releaseCheck.sh
+++ b/sbin/releaseCheck.sh
@@ -10,14 +10,18 @@ TEMURIN_TAG=$2
 VERBOSE=$3
 
 echo Grabbing information from https://github.com/adoptium/temurin${TEMURIN_VERSION}-binaries/releases/tag/${TEMURIN_TAG}
-curl -q https://github.com/adoptium/temurin${TEMURIN_VERSION}-binaries/releases/tag/${TEMURIN_TAG} > releaseCheck.$$.tmp || exit 1
+FILTER=$(echo $TEMURIN_TAG | sed 's/+/%2B/g')
+echo FILTER IS: $FILTER
+curl -q https://api.github.com/repos/adoptium/temurin${TEMURIN_VERSION}-binaries/releases |
+   grep "$FILTER" |
+   awk -F'"' '/browser_download_url/{print$4}' > releaseCheck.$$.tmp || exit 1
 
 #### LINUX (ALL)
 for ARCH in x64 aarch64 ppc64le s390x arm; do
   # jre, jdk, debugimage, static-libs (Except JDK8) in base, json, sha256, GPG sig. SBOM ONLY HAS 2
-  EXPECTED=18; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=14
+  EXPECTED=19; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=15
   if ! [ "${TEMURIN_VERSION}" -eq 8 -a "$ARCH" = "s390x" ]; then
-    ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_linux | grep href | cut -d'"' -f2 | wc -l)
+    ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_linux | wc -l)
     if [ $ACTUAL -eq $EXPECTED ]
     then
        echo "Linux on $ARCH: OK!"
@@ -25,16 +29,16 @@ for ARCH in x64 aarch64 ppc64le s390x arm; do
       if [ $ACTUAL -eq 0 ]; then
         echo "Linux on $ARCH: Not published:"
       else
-        echo "Linux on $ARCH: Incomplete: Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 2 SBOM)"
+        echo "Linux on $ARCH: Incomplete: $ACTUAL/$EXPECTED Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 2 SBOM)"
       fi
-      [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_linux | grep href | cut -d'"' -f2
+      [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_linux
     fi
   fi
 done
 
 ### AIX - Same number of artifacts as Linux so don't adjust EXPECTED
 for ARCH in ppc64; do
-  ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_aix | grep href | cut -d'"' -f2 | wc -l)
+  ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_aix | wc -l)
   if [ $ACTUAL -eq $EXPECTED ]
   then
     echo "AIX on $ARCH: OK!"
@@ -42,15 +46,15 @@ for ARCH in ppc64; do
     if [ $ACTUAL -eq 0 ]; then
       echo "AIX on $ARCH: Not published:"
     else
-      echo "AIX on $ARCH: Incomplete: Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 2 SBOMs"
+      echo "AIX on $ARCH: Incomplete: $ACTUAL/$EXPECTED Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 3 SBOMs"
     fi
-    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_aix | grep href | cut -d'"' -f2
+    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_aix
   fi
 done
 
 ### Alpine - Same number of artifacts as Linux so don't adjust EXPECTED
 for ARCH in x64; do
-  ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_alpine | grep href | cut -d'"' -f2 | wc -l)
+  ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_alpine | wc -l)
   if [ $ACTUAL -eq $EXPECTED ]
   then
      echo "Alpine on $ARCH: OK!"
@@ -58,16 +62,16 @@ for ARCH in x64; do
     if [ $ACTUAL -eq 0 ]; then
       echo "Alpine on $ARCH: Not published:"
     else
-      echo "Alpine on $ARCH: INCOMPLETE: Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 2 SBOMs"
+      echo "Alpine on $ARCH: INCOMPLETE: $ACTUAL/$EXPECTED Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 3 SBOMs"
     fi
-    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_alpine | grep href | cut -d'"' -f2
+    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_alpine
   fi
 done
  
 ### Solaris - Same number of artifacts as Linux so don't adjust EXPECTED
 if [ "${TEMURIN_VERSION}" -eq 8 ]; then
   for ARCH in x64 sparcv9; do
-    ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_solaris | grep href | cut -d'"' -f2 | wc -l)
+    ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_solaris | wc -l)
     if [ $ACTUAL -eq $EXPECTED ]
     then
       echo "Solaris on $ARCH: OK!"
@@ -75,9 +79,9 @@ if [ "${TEMURIN_VERSION}" -eq 8 ]; then
       if [ $ACTUAL -eq 0 ]; then
         echo "Solaris on $ARCH: Not published:"
       else
-        echo "Solaris on $ARCH: INCOMPLETE: Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 2 SBOMs"
+        echo "Solaris on $ARCH: INCOMPLETE: $ACTUAL/$EXPECTED Expect jre, jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 3 SBOMs"
       fi
-      [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_solaris | grep href | cut -d'"' -f2
+      [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_solaris
     fi
   done
 fi
@@ -85,8 +89,8 @@ fi
 #### WINDOWS
 for ARCH in x64 x86-32; do
   # jre, jdk, jre-msi, jdk-msi, debugimage, static-libs (Except JDK8) in base, json, sha256
-  EXPECTED=26; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=22
-  ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_windows | grep href | cut -d'"' -f2 | wc -l)
+  EXPECTED=27; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=23
+  ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_windows | wc -l)
   if [ $ACTUAL -eq $EXPECTED ]
   then
      echo "Windows on $ARCH: OK!"
@@ -94,18 +98,18 @@ for ARCH in x64 x86-32; do
     if [ $ACTUAL -eq 0 ]; then
       echo "Windows on $ARCH: Not published"
     else
-      echo "Windows on $ARCH: INCOMPLETE: $EXPECTED (Expect jre, jdk, msi-jre msi-jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 2 SBOMs"
+      echo "Windows on $ARCH: INCOMPLETE: $ACTUAL/$EXPECTED  (Expect jre, jdk, msi-jre msi-jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 3 SBOMs"
     fi
-    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_windows | grep href | cut -d'"' -f2
+    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_windows
   fi
 done
 
 ### MAC
 for ARCH in x64 aarch64; do
   # jre, jdk, jre-pkg, jdk-pkg, debugimage, static-libs (Except JDK8) in base, json, sha256
-  EXPECTED=26; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=22
+  EXPECTED=27; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=23
   if ! [ "${TEMURIN_VERSION}" -eq 8 -a "$ARCH" = "aarch64" ]; then
-    ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_mac | grep href | cut -d'"' -f2 | wc -l)
+    ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_mac | wc -l)
     if [ $ACTUAL -eq $EXPECTED ]
     then
       echo "MacOS on $ARCH: OK!"
@@ -113,19 +117,19 @@ for ARCH in x64 aarch64; do
       if [ $ACTUAL -eq 0 ]; then
         echo "MacOS on $ARCH: Not Published:"
       else
-        echo "MacOS on $ARCH: INCOMPLETE: (Expect jre, jdk, pkg-jre, pkg-jdk, debugimage, static-libs (Not JD8) in base, json, sha256, sig)"
+        echo "MacOS on $ARCH: INCOMPLETE: $ACTUAL/$EXPECTED (Expect jre, jdk, pkg-jre, pkg-jdk, debugimage, static-libs (Not JD8) in base, json, sha256, sig)"
       fi
-      [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_mac | grep href | cut -d'"' -f2
+      [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_mac
     fi
   fi
 done
 
-if [ $(cat releaseCheck.$$.tmp | grep sources | grep href | cut -d'"' -f2 | wc -l) -eq 4 ]
+if [ $(cat releaseCheck.$$.tmp | grep sources | wc -l) -eq 4 ]
 then
    echo "Source images: OK!"
 else
    echo "Source images: Not complete:"
-   [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep sources | grep href | cut -d'"' -f2
+   [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep sources
 fi
 
-rm releaseCheck.$$.tmp
+# rm releaseCheck.$$.tmp

--- a/sbin/releaseCheck.sh
+++ b/sbin/releaseCheck.sh
@@ -98,7 +98,7 @@ for ARCH in x64 x86-32; do
     if [ $ACTUAL -eq 0 ]; then
       echo "Windows on $ARCH: Not published"
     else
-      echo "Windows on $ARCH: INCOMPLETE: $ACTUAL/$EXPECTED  (Expect jre, jdk, msi-jre msi-jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 3 SBOMs"
+      echo "Windows on $ARCH: INCOMPLETE: $ACTUAL/$EXPECTED (Expect jre, jdk, msi-jre msi-jdk, debugimage, static-libs (Not JDK8) in base, json, sha256, GPG sig, plus 3 SBOMs"
     fi
     [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep ${ARCH}_windows
   fi
@@ -132,4 +132,4 @@ else
    [ ! -z "$VERBOSE" ] && cat releaseCheck.$$.tmp | grep sources
 fi
 
-# rm releaseCheck.$$.tmp
+rm releaseCheck.$$.tmp


### PR DESCRIPTION
Release tool will not be able to do its checks in the job output without this

Signed-off-by: Stewart X Addison <sxa@redhat.com>