### PR TITLE
Add release notes filter to UploadFiles.groovy

### DIFF
--- a/adopt-github-release/src/main/groovy/net/adoptium/release/UploadFiles.groovy
+++ b/adopt-github-release/src/main/groovy/net/adoptium/release/UploadFiles.groovy
@@ -33,9 +33,11 @@ class UploadAdoptReleaseFiles {
     void release() {
         def grouped = files.groupBy {
             switch (it.getName()) {
-                // Only release file names containing "hotspot" or "sources"
+                // Only release file names containing certain patterns
+                // to avoid publication of non-temurin builds
                 case ~/.*hotspot.*/: "adopt"; break;
                 case ~/.*sources.*/: "adopt"; break;
+                case ~/.*release-notes.*/: "adopt"; break;
                 case ~/.*AQAvitTapFiles.*/: "adopt"; break;
             }
         }


### PR DESCRIPTION
refactor_openjdk_release_tool is currently unable to publish the release notes because there is an additional filter in the UploadFiles.groovy script on top of the one that's in the jenkins job. This fixes that problem.

