### PR TITLE
Correct releaseCheck.sh path and revert jdk version to lowercase

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     parameters {
         password(name: 'GITHUB_TOKEN', defaultValue: 'SECRET', description: 'Leave this')
         string(name: 'TAG', defaultValue: '', description: 'The GitHub tag of the release, e.g. jdk-12+33')
-        choice(name: 'VERSION', choices: ['JDK21', 'JDK20', 'JDK19', 'JDK17', 'JDK11', 'JDK8'], description: 'Which JDK Version?')
+        choice(name: 'VERSION', choices: ['jdk21', 'jdk20', 'jdk19', 'jdk17', 'jdk11', 'jdk8'], description: 'Which JDK Version?')
         string(name: 'UPSTREAM_JOB_NAME', defaultValue: '', description: 'The full path to the pipeline / job, e.g. build-scripts/openjdk12-pipeline')
         string(name: 'UPSTREAM_JOB_NUMBER', defaultValue: '', description: 'The build number of the pipeline / job you want to release, e.g. 92')
         string(name: 'UPSTREAM_JOB_LINK', defaultValue: '', description: 'The build link of the pipeline / job you want to release, e.g. 92')
@@ -58,7 +58,10 @@ Or **/*x64_linux*.tar.gz,**/*x64_linux*.sha256.txt,**/*x64_linux*.json,**/*x64_l
                             excludes: "${params.ARTIFACTS_TO_SKIP}",
                             projectName: "${upstreamJobName}",
                             selector: [$class: 'SpecificBuildSelector', buildNumber: "${upstreamJobNumber}"]])
-                        sh 'JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ./sbin/Release.sh'
+                        sh '''
+                        export VERSION=`echo $VERSION | awk '{print toupper($0)}'`
+                        JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ./sbin/Release.sh
+                        '''
                     } catch (Exception err) {
                         echo err.getMessage()
                         currentBuild.result = 'FAILURE'

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -148,7 +148,7 @@ RELEASE_OPTION=""
 if [ "$RELEASE" == "true" ]; then
   description="Official Release of $TAG"
   RELEASE_OPTION="--release"
-else if [ "$UPLOAD_TESTRESULTS_ONLY" == "true" ]; then
+elif [ "$UPLOAD_TESTRESULTS_ONLY" == "true" ]; then
   echo "Test results are only needed to upload for releases!"
   exit 1
 else
@@ -165,6 +165,6 @@ if [ "$DRY_RUN" == "false" ]; then
     # Run releaseCheck.sh to check that the correct number of artifacts are live
     if [ -z "$TIMESTAMP" -a "$UPLOAD_TESTRESULTS_ONLY" = "false" ]; then
       echo "*** PERFORMING RELEASE CHECK TO SEE IF THERE ARE ANY UNEXPECTED PROBLEMS ***"
-      ./sbin/releaseCheck.sh ${VERSION#JDK} $TAG VERBOSE
+      .releaseCheck.sh ${VERSION#JDK} $TAG VERBOSE
     fi
 fi


### PR DESCRIPTION
Wrong releaseCheck.sh path
Correct else if  -> elif
Revert to use lowercase jdkversion to work with current jdk pipeline build job

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>