### PR TITLE
Enable -xeo pipeline to correctly return the sh command code

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -26,6 +26,8 @@
 # documentation of the variables using the POSIX standard
 #
 ###################################################################
+set -x
+set -eo pipefail
 
 # Our timestamps must fit this particular format: YYYY-DD-MM-hh-mm, e.g. 2021-07-30-16-11
 timestampRegex="[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]{2}"


### PR DESCRIPTION
So jenkins job can correctly show the job status

Fix #116 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>