### PR TITLE
Ensure Release.sh does not exit if .sig/json/sha256.txt is not present or being selected

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -87,10 +87,10 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
       if [ "${file}" != "${newName}" ]; then
         # Rename archive and its associated files with new timestamp
         echo "Renaming ${file} to ${newName}"
-        mv "${file}" "${newName}"
-        mv "${file}.sha256.txt" "${newName}.sha256.txt"
-        mv "${file}.json" "${newName}.json"
-        mv "${file}.sig" "${newName}.sig"
+        [ -f "${file}" ] && mv "${file}" "${newName}"
+        [ -f "${file}.sha256.txt" ] && mv "${file}.sha256.txt" "${newName}.sha256.txt"
+        [ -f "${file}.json" ] && mv "${file}.json" "${newName}.json"
+        [ -f "${file}.sig" ] && mv "${file}.sig" "${newName}.sig"
       fi
 
       # Fix checksum file name

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -144,7 +144,9 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
   # Grab the list of files to upload
   # TODO - shellcheck (SC2012) tells us that using find is better than ls here.
   # NOTE: If adding something here you may need to change the EXPECTED values in releaseCheck.sh
+  echo "HERE1"
   files=$(ls "$PWD"/OpenJDK*{.tar.gz,.sha256.txt,.zip,.pkg,.msi,.json,*.sig} | grep -v makefailurelogs | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g')
+  echo "HERE2"
 else 
   #TODO: enhance to a general file name - update groovy release() - case ~/.*AQAvitTapFiles.*/: "adopt"; break;
   files=$(ls "$PWD"/AQAvitTapFiles.tar.gz)

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -143,7 +143,7 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
   done
   # Grab the list of files to upload
   # NOTE: If adding something here you may need to change the EXPECTED values in releaseCheck.sh
-  files=$(find $PWD \( -name "*.tar.gz" -o -name "*.sha256.txt" -o -name "*.zip" -o -name "*.pkg" -o -name "*.msi" -o -name "*.json" -o -name "*.sig" \) -exec basename {} \; | tr '\n' ' ')
+  files=$(find $PWD \( -name "*.tar.gz" -o -name "*.sha256.txt" -o -name "*.zip" -o -name "*.pkg" -o -name "*.msi" -o -name "*.json" -o -name "*.sig" \) | tr '\n' ' ')
 else 
   #TODO: enhance to a general file name - update groovy release() - case ~/.*AQAvitTapFiles.*/: "adopt"; break;
   files=$(ls "$PWD"/AQAvitTapFiles.tar.gz)

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -143,7 +143,7 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
   done
   # Grab the list of files to upload
   # NOTE: If adding something here you may need to change the EXPECTED values in releaseCheck.sh
-  files=$(find $PWD \( -name "OpenJDK*.tar.gz" -o -name "OpenJDK*.sha256.txt" -o -name "OpenJDK*.zip" -o -name "OpenJDK*.pkg" -o -name "OpenJDK*.msi" -o -name "OpenJDK*.json" -o -name "OpenJDK*.sig" \) | tr '\n' ' ')
+  files=$(find $PWD \( -name "OpenJDK*.tar.gz" -o -name "OpenJDK*.sha256.txt" -o -name "OpenJDK*.zip" -o -name "OpenJDK*.pkg" -o -name "OpenJDK*.msi" -o -name "OpenJDK*.json" -o -name "OpenJDK*.sig" \) | grep -v "makefailurelogs" | tr '\n' ' ')
 else 
   #TODO: enhance to a general file name - update groovy release() - case ~/.*AQAvitTapFiles.*/: "adopt"; break;
   files=$(ls "$PWD"/AQAvitTapFiles.tar.gz)

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -87,10 +87,18 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
       if [ "${file}" != "${newName}" ]; then
         # Rename archive and its associated files with new timestamp
         echo "Renaming ${file} to ${newName}"
-        [ -f "${file}" ] && mv "${file}" "${newName}"
-        [ -f "${file}.sha256.txt" ] && mv "${file}.sha256.txt" "${newName}.sha256.txt"
-        [ -f "${file}.json" ] && mv "${file}.json" "${newName}.json"
-        [ -f "${file}.sig" ] && mv "${file}.sig" "${newName}.sig"
+        if [ -f "${file}" ]; then
+          mv "${file}" "${newName}"
+        fi
+        if [ -f "${file}.sha256.txt" ]; then
+          mv "${file}.sha256.txt" "${newName}.sha256.txt"
+        fi
+        if [ -f "${file}.json" ]; then
+          mv "${file}.json" "${newName}.json"
+        fi
+        if [ -f "${file}.sig" ]; then
+          mv "${file}.sig" "${newName}.sig"
+        fi
       fi
 
       # Fix checksum file name

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -143,7 +143,7 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
   done
   # Grab the list of files to upload
   # NOTE: If adding something here you may need to change the EXPECTED values in releaseCheck.sh
-  files=$(find $PWD \( -name "*.tar.gz" -o -name "*.sha256.txt" -o -name "*.zip" -o -name "*.pkg" -o -name "*.msi" -o -name "*.json" -o -name "*.sig" \) | tr '\n' ' ')
+  files=$(find $PWD \( -name "OpenJDK*.tar.gz" -o -name "OpenJDK*.sha256.txt" -o -name "OpenJDK*.zip" -o -name "OpenJDK*.pkg" -o -name "OpenJDK*.msi" -o -name "OpenJDK*.json" -o -name "OpenJDK*.sig" \) | tr '\n' ' ')
 else 
   #TODO: enhance to a general file name - update groovy release() - case ~/.*AQAvitTapFiles.*/: "adopt"; break;
   files=$(ls "$PWD"/AQAvitTapFiles.tar.gz)

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -142,11 +142,8 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
     fi
   done
   # Grab the list of files to upload
-  # TODO - shellcheck (SC2012) tells us that using find is better than ls here.
   # NOTE: If adding something here you may need to change the EXPECTED values in releaseCheck.sh
-  echo "HERE1"
-  files=$(ls "$PWD"/OpenJDK*{.tar.gz,.sha256.txt,.zip,.pkg,.msi,.json,*.sig} | grep -v makefailurelogs | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g')
-  echo "HERE2"
+  files=$(find $PWD \( -name "*.tar.gz" -o -name "*.sha256.txt" -o -name "*.zip" -o -name "*.pkg" -o -name "*.msi" -o -name "*.json" -o -name "*.sig" \) -exec basename {} \; | tr '\n' ' ')
 else 
   #TODO: enhance to a general file name - update groovy release() - case ~/.*AQAvitTapFiles.*/: "adopt"; break;
   files=$(ls "$PWD"/AQAvitTapFiles.tar.gz)

--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -112,7 +112,7 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
   # Rename any remaining non-archive file timestamps that have not already been renamed
   for file in OpenJDK*
   do
-    if [[ ! $file =~ $regexArchivesOnly ]];
+    if [[ ! $file =~ $regexArchivesOnly && ! $file =~ *makefailurelogs* ]];
     then
       echo "Processing non-archive file: $file";
 
@@ -136,7 +136,7 @@ if [ "$UPLOAD_TESTRESULTS_ONLY" == "false" ]; then
   # Grab the list of files to upload
   # TODO - shellcheck (SC2012) tells us that using find is better than ls here.
   # NOTE: If adding something here you may need to change the EXPECTED values in releaseCheck.sh
-  files=$(ls "$PWD"/OpenJDK*{.tar.gz,.sha256.txt,.zip,.pkg,.msi,.json,*.sig} | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g')
+  files=$(ls "$PWD"/OpenJDK*{.tar.gz,.sha256.txt,.zip,.pkg,.msi,.json,*.sig} | grep -v makefailurelogs | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g')
 else 
   #TODO: enhance to a general file name - update groovy release() - case ~/.*AQAvitTapFiles.*/: "adopt"; break;
   files=$(ls "$PWD"/AQAvitTapFiles.tar.gz)


### PR DESCRIPTION
Ensure Release.sh does not immediately exit if one of the platforms does not have all the artifacts.
Ensure it does not abort if makefailurelogs found.

Fixes: https://github.com/adoptium/github-release-scripts/issues/117
