### PR TITLE
releaseCheck: fix non-POSIX syntax for Alpine

### DIFF
--- a/sbin/releaseCheck.sh
+++ b/sbin/releaseCheck.sh
@@ -59,7 +59,7 @@ done
 ### Alpine - Same number of artifacts as Linux so don't adjust EXPECTED
 for ARCH in x64 aarch64; do
   # Alpine/aarch64 is only included from JDK21
-  if [ "${TEMURIN_VERSION}" -ge 21 -o "${ARCH}" == "x64" ]; then
+  if [ "${TEMURIN_VERSION}" -ge 21 -o "${ARCH}" = "x64" ]; then
     ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_alpine | wc -l)
     if [ $ACTUAL -eq $EXPECTED ]
     then


### PR DESCRIPTION
Removes bash-specific syntax.

Unlike me to make this sort of error as I'm generally quite picky about it :-) The problem didn't show up on my development Fedora system but has an issue on Linux systems using `dash` by default.

Fixes #145 
Also referred to in https://github.com/adoptium/temurin/issues/13#issuecomment-1900826057