### PR TITLE
Allow for beta EA archive filenames that contain -ea

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -39,9 +39,10 @@ timestampRegex="[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]{2}-[[:d
 #      OpenJDK 18U             -jdk-sources                                               2020-06-06-16-36                .tar.gz
 #      OpenJDK 11_             -jdk        x64_           linux_         _fast_startup_   11_28                           .tar.gz
 #      OpenJDK                 -debugimage aarch64_       linux_         hotspot_         2023-02-16-12-32                .tar.gz
+#      OpenJDK 17U_            -jdk        x64_           linux_         hotspot_         17.0.10_5-ea                    .tar.gz
 #
-#             (version     )  (type                                                                                           ) (arch           ) (os             ) (variant         ) (timestamp     or version      )  (extension          )
-regex="OpenJDK([[:digit:]]*)U?(-jre|-jdk|-debugimage|-static-libs-glibc|-static-libs|-static-libs-musl|-testimage|-jdk-sources)_([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:alnum:]\-_]+_)?([[:digit:]\-]+|[[:alnum:]\._]+)\.(tar\.gz|zip|pkg|msi)";
+#             (version     )  (type                                                                                           ) (arch           ) (os             ) (variant         ) (timestamp     or version        )  (extension          )
+regex="OpenJDK([[:digit:]]*)U?(-jre|-jdk|-debugimage|-static-libs-glibc|-static-libs|-static-libs-musl|-testimage|-jdk-sources)_([[:alnum:]\-]+_)?([[:alnum:]\-]+_)?([[:alnum:]\-_]+_)?([[:digit:]\-]+|[[:alnum:]\._\-]+)\.(tar\.gz|zip|pkg|msi)";
 
 regexArchivesOnly="${regex}$";
 


### PR DESCRIPTION
As part of enabling beta EA tag driven builds the archive file name regex needs updating to allow timestamp|version field containing "-ea"
ref: https://github.com/adoptium/ci-jenkins-pipelines/issues/902#issue-2105958248