### PR TITLE
Increase release tool java max heap size

### DIFF
--- a/adopt-github-release/build.gradle
+++ b/adopt-github-release/build.gradle
@@ -11,10 +11,11 @@ repositories {
 }
 application {
     mainClassName = 'net.adoptium.release.UploadFiles'
+    applicationDefaultJvmArgs = ['-Xmx2g']
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.5.6'
-    implementation 'org.kohsuke:github-api:1.127'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.20'
+    implementation 'org.kohsuke:github-api:1.318'
     compileOnly group: 'junit', name: 'junit', version: '4.12'
 }

--- a/adopt-github-release/gradle/wrapper/gradle-wrapper.properties
+++ b/adopt-github-release/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes https://github.com/adoptium/github-release-scripts/issues/149

When a large number of artifacts need to be published for a nightly beta build, the heap runs out of space.
Increase max heap setting of gradle app to 2g and upgrade to running under jdk-21
