### PR TITLE
Update release checks for arm and riscv64

### DIFF
--- a/sbin/releaseCheck.sh
+++ b/sbin/releaseCheck.sh
@@ -19,10 +19,12 @@ curl -q https://api.github.com/repos/adoptium/temurin${TEMURIN_VERSION}-binaries
    awk -F'"' '/browser_download_url/{print$4}' > releaseCheck.$$.tmp || exit 1
 
 #### LINUX (ALL)
-for ARCH in x64 aarch64 ppc64le s390x arm; do
+for ARCH in x64 aarch64 ppc64le s390x arm riscv64; do
   EXPECTED=23; [ "${TEMURIN_VERSION}" -eq 8 ] && EXPECTED=15
-  # Temurin does not ship on Linux/s390x for JDK8
-  if ! [ "${TEMURIN_VERSION}" -eq 8 -a "$ARCH" = "s390x" ]; then
+  # Exclude checks for platform/versions that Temurin does not ship on
+  if ! [ \( "${TEMURIN_VERSION}" -eq  8 -a "$ARCH" = "s390x" \) -o \
+         \( "${TEMURIN_VERSION}" -ge 20 -a "$ARCH" = "arm"   \) -o \
+         \( "${TEMURIN_VERSION}" -lt 21 -a "$ARCH" = "riscv64" \) ]; then
     ACTUAL=$(cat releaseCheck.$$.tmp | grep ${ARCH}_linux | wc -l)
     if [ $ACTUAL -eq $EXPECTED ]
     then


### PR DESCRIPTION
Exclude JDK21 for arm32. Include 21+ for riscv64