### PR TITLE
releaseCheck: Don't pick up beta builds when checking GA

### DIFF
--- a/sbin/releaseCheck.sh
+++ b/sbin/releaseCheck.sh
@@ -15,7 +15,7 @@ echo Grabbing information from https://github.com/adoptium/temurin${TEMURIN_VERS
 FILTER=$(echo $TEMURIN_TAG | sed 's/+/%2B/g')
 echo FILTER IS: $FILTER
 curl -q https://api.github.com/repos/adoptium/temurin${TEMURIN_VERSION}-binaries/releases |
-   grep "$FILTER" |
+   grep "/$FILTER/" |
    awk -F'"' '/browser_download_url/{print$4}' > releaseCheck.$$.tmp || exit 1
 
 #### LINUX (ALL)


### PR DESCRIPTION
Currently the code uses a grep on the output that will pick up e.g. `jdk-xx.0.1+y-ea-beta` when searching for `jdk-xx.0.1+y`. This adds `/` around the regex so it will only pick up the entries for the release that it's searching for.