### PR TITLE
bump CI to Java 21 + add Node.js testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,9 @@ jobs:
     - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '21'
         cache: 'gradle'
 
     - name: Run Groovy Tests
-      run: |
-        cd adopt-github-release
-        ./gradlew --info test
+      working-directory: adopt-github-release
+      run: ./gradlew --info test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,24 @@ jobs:
     - name: Run Groovy Tests
       working-directory: adopt-github-release
       run: ./gradlew --info test
+
+  test_node:
+    name: Node
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+    - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: 'generate-release-notes/generate-release-notes/package-lock.json'
+
+    - name: Install Node Dependencies
+      working-directory: generate-release-notes/generate-release-notes
+      run: npm install
+
+    - name: Run Tests
+      working-directory: generate-release-notes/generate-release-notes
+      run: npm test

--- a/generate-release-notes/generate-release-notes/test/fetchGitHubCommitsTest.js
+++ b/generate-release-notes/generate-release-notes/test/fetchGitHubCommitsTest.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { fetchCommits } from '../lib/fetchGItHubCommits.js';
+import { fetchCommits } from '../lib/fetchGitHubCommits.js';
 import mockAPIResponse from './mock/mockAPIResponse.json' assert { type: 'json' };
 
 const repository = 'adoptium/jdk17u'


### PR DESCRIPTION
bumps the Gradle test CI to Java 21

Also adds Node testing for the generate-release-notes tool