### PR TITLE
Fix codefreeze to check PR target branch correctly

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -16,8 +16,6 @@ name: Code Freeze Bot
 # Controls when the workflow will run
 on:
   pull_request_target:
-    branches:
-      - '*'
   issue_comment:
     types: [created]
 

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,9 +1,23 @@
+# ********************************************************************************
+# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Apache Software License 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************
+
 name: Code Freeze Bot
 
 # Controls when the workflow will run
 on:
   pull_request_target:
-    branches: [ "master" ]
+    branches:
+      - '*'
   issue_comment:
     types: [created]
 
@@ -12,6 +26,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  codefreeze:
+  # Check if the pull request target branch matches the required branch-regex?
+  codefreeze_branch_check:
+    uses: adoptium/.github/.github/workflows/code-freeze-regex-branch.yml@main
+    with:
+      branch-regex: "^master$"
+
+  # Code freeze if branch-regex matches
+  codefreeze_if_branch_match:
+    needs: codefreeze_branch_check
     uses: adoptium/.github/.github/workflows/code-freeze.yml@main
+    if: (github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) && needs.codefreeze_branch_check.outputs.regex-matches == 'true'
     secrets: inherit


### PR DESCRIPTION
Fixes https://github.com/adoptium/.github/issues/121

Update code-freeze action to use the new regex branch check workflow

Note: github-release-scripts repo freezes the master branch
