### PR TITLE
change wording for GH releases

### DIFF
--- a/sbin/Release.sh
+++ b/sbin/Release.sh
@@ -155,7 +155,7 @@ echo ""
 
 RELEASE_OPTION=""
 if [ "$RELEASE" == "true" ]; then
-  description="Official Release of $TAG"
+  description="Official Eclipse Temurin Release of $TAG"
   RELEASE_OPTION="--release"
 elif [ "$UPLOAD_TESTRESULTS_ONLY" == "true" ]; then
   echo "Test results are only needed to upload for releases!"


### PR DESCRIPTION
The Eclipse Foundation is concerned that the Eclipse Temurin project’s release descriptions on GitHub could be confusing for consumers. Therefore the  Eclipse Foundation directs the  Temurin project to change the GitHub release descriptions from Official Release of jdk-x.x.x to Official Eclipse Temurin Release of jdk-x.x.x for all future releases.