### PR TITLE
Allow underscores in devkit distribution name when publishing

### DIFF
--- a/sbin/PublishDevKit.sh
+++ b/sbin/PublishDevKit.sh
@@ -26,9 +26,9 @@ set -eo pipefail
 
 # eg: artifact:
 # devkit-gcc-11.3.0-Centos7.6.1810-b01-x86_64-linux-gnu.tar.gz
-
-#              (compiler    )  (version      ) (sysroot       ) (build       )-(arch          )(suffix    )  (extension                                )
-regex="^devkit-([[:alnum:]]+)-([[:digit:]\.]+)-([[:alnum:]\.]+)-([[:alnum:]]+)-([[:alnum:]\_]+)(-linux-gnu)\.(tar\.xz|tar\.xz\.sha256\.txt|tar\.xz\.sig)$";
+# devkit-gcc-14.2.0-Fedora_28-b00-riscv64-linux-gnu.tar.xz
+#              (compiler    )  (comp version ) (OS sysroot     ) (build       )-(arch          )(suffix    )  (extension                                )
+regex="^devkit-([[:alnum:]]+)-([[:digit:]\.]+)-([[:alnum:]\._]+)-([[:alnum:]]+)-([[:alnum:]\_]+)(-linux-gnu)\.(tar\.xz|tar\.xz\.sha256\.txt|tar\.xz\.sig)$";
 
 # Check that a TAG has been passed in.
 if [ -z "${TAG}" ]; then


### PR DESCRIPTION
Fedora riscv64 devkit has `Fedora_28` in the name which is blocked by the [devkit publish tool's regex](https://ci.adoptium.net/job/build-scripts/job/release/job/publish_devkit_tool/122/console):
```
+ JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-arm64 bash ./sbin/PublishDevKit.sh
ERROR: devkit file does not match required regex pattern: devkit-gcc-14.2.0-Fedora_28-b00-riscv64-linux-gnu.tar.xz
ERROR: devkit file does not match required regex pattern: devkit-gcc-14.2.0-Fedora_28-b00-riscv64-linux-gnu.tar.xz.sha256.txt
ERROR: devkit file does not match required regex pattern: devkit-gcc-14.2.0-Fedora_28-b00-riscv64-linux-gnu.tar.xz.sig
ERROR: Some devkit filenames are not valid...
```
Related slack thread: https://adoptium.slack.com/archives/C09NW3L2J/p1743177415374159