### PR TITLE
Correct release notes Jira issue fetch

### DIFF
--- a/generate-release-notes/generate-release-notes/fetchReleaseNotes.js
+++ b/generate-release-notes/generate-release-notes/fetchReleaseNotes.js
@@ -34,7 +34,7 @@ const JIRA_ISSUES = await fetchJiraIssues(version);
 
 // loop through the commits and add the release notes to the output
 for (const commit of commits) {
-console.log(`COMMIT ${commit}`)
+console.log(`COMMIT ${commit.id}`)
   let releaseNote = JIRA_ISSUES
     .find((issue) => issue.id === commit.id || issue.backportOf === commit.id);
 

--- a/generate-release-notes/generate-release-notes/fetchReleaseNotes.js
+++ b/generate-release-notes/generate-release-notes/fetchReleaseNotes.js
@@ -34,7 +34,6 @@ const JIRA_ISSUES = await fetchJiraIssues(version);
 
 // loop through the commits and add the release notes to the output
 for (const commit of commits) {
-console.log(`COMMIT ${commit.id}`)
   let releaseNote = JIRA_ISSUES
     .find((issue) => issue.id === commit.id || issue.backportOf === commit.id);
 

--- a/generate-release-notes/generate-release-notes/fetchReleaseNotes.js
+++ b/generate-release-notes/generate-release-notes/fetchReleaseNotes.js
@@ -34,6 +34,7 @@ const JIRA_ISSUES = await fetchJiraIssues(version);
 
 // loop through the commits and add the release notes to the output
 for (const commit of commits) {
+console.log(`COMMIT ${commit}`)
   let releaseNote = JIRA_ISSUES
     .find((issue) => issue.id === commit.id || issue.backportOf === commit.id);
 

--- a/generate-release-notes/generate-release-notes/lib/fetchJiraIssues.js
+++ b/generate-release-notes/generate-release-notes/lib/fetchJiraIssues.js
@@ -32,6 +32,7 @@ export default async function fetchReleaseNotes(version) {
         });
       }
 
+console.log(`ISSUE: ${issue.key}`)
       JIRA_ISSUES.push({
         id: issue.key,
         title: issue.fields.summary,

--- a/generate-release-notes/generate-release-notes/lib/fetchJiraIssues.js
+++ b/generate-release-notes/generate-release-notes/lib/fetchJiraIssues.js
@@ -5,7 +5,7 @@ export default async function fetchReleaseNotes(version) {
   const jql = `project=JDK AND (status in (Closed, Resolved))
     AND (resolution not in ("Won't Fix", "Duplicate", "Cannot Reproduce", "Not an Issue", "Withdrawn"))
     AND (labels not in (release-note, openjdk-na) OR labels is EMPTY)
-    AND (summary !~ "release note") AND (issuetype != CSR) AND fixVersion=${version}`;
+    AND (summary !~ "release note") AND (issuetype != CSR) AND (fixVersion in (${version}))`;
   // execute the initial fetch to get the total number of issues
   const totalQuery = await fetch(`${baseUrl + jql}&startAt=1&maxResults=1`);
   const initialRes = await totalQuery.json();

--- a/generate-release-notes/generate-release-notes/lib/fetchJiraIssues.js
+++ b/generate-release-notes/generate-release-notes/lib/fetchJiraIssues.js
@@ -32,7 +32,6 @@ export default async function fetchReleaseNotes(version) {
         });
       }
 
-console.log(`ISSUE: ${issue.key}`)
       JIRA_ISSUES.push({
         id: issue.key,
         title: issue.fields.summary,


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4200

The Jira bug query needs to correctly match the bug database fixVersion used, which for jdk8u is either openjdk8u462 or 8u461

The Jenkins job JDK_VERSION Parameter description has been updated to indicate the required fixVersion values:
```
Upstream JDK Jira Issue fixVersion list (comma separated)

For jdk-11+: In the form MM.0.F. Eg.17.0.1. Note: 18.0.2.1 would be 18.0.2. E.g 20+36 would be 20

For jdk8: Must match openjdkPSU,CPU. eg.openjdk8u462,8u461

EXAMPLES:

21.0.8

openjdk8u462,8u461
```
